### PR TITLE
Add start and course selection views with keypad scorecard

### DIFF
--- a/golfy/golfy/ContentView.swift
+++ b/golfy/golfy/ContentView.swift
@@ -8,7 +8,10 @@ struct ContentView: View {
     var body: some View {
         TabView {
             NavigationView { StartRoundView() }
-                .tabItem { Label("Rounds", systemImage: "list.bullet") }
+                .tabItem { Label("Home", systemImage: "house") }
+
+            NavigationView { CourseListView() }
+                .tabItem { Label("Courses", systemImage: "mappin.circle") }
 
             if let course {
                 NavigationView {
@@ -21,8 +24,11 @@ struct ContentView: View {
                     .tabItem { Label("GPS", systemImage: "flag") }
             }
 
-            NavigationView { ScorecardView(scorecard: scorecard) }
-                .tabItem { Label("Scorecard", systemImage: "pencil") }
+            NavigationView { HistoryView() }
+                .tabItem { Label("History", systemImage: "clock") }
+
+            NavigationView { ProfileView() }
+                .tabItem { Label("Profile", systemImage: "person.crop.circle") }
         }
         .task {
             if course == nil {

--- a/golfy/golfy/ContentView.swift
+++ b/golfy/golfy/ContentView.swift
@@ -7,16 +7,19 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
+            NavigationView { StartRoundView() }
+                .tabItem { Label("Rounds", systemImage: "list.bullet") }
+
             if let course {
                 NavigationView {
                     HolePagerView(course: course, locationManager: locationManager, scorecard: scorecard)
                         .navigationTitle(course.name)
                 }
-                .tabItem { Label("Play", systemImage: "flag") }
+                .tabItem { Label("GPS", systemImage: "flag") }
             } else {
                 Text("Loading course...")
                     .task { await loadCourse() }
-                    .tabItem { Label("Play", systemImage: "flag") }
+                    .tabItem { Label("GPS", systemImage: "flag") }
             }
 
             NavigationView { ScorecardView(scorecard: scorecard) }

--- a/golfy/golfy/ContentView.swift
+++ b/golfy/golfy/ContentView.swift
@@ -17,13 +17,17 @@ struct ContentView: View {
                 }
                 .tabItem { Label("GPS", systemImage: "flag") }
             } else {
-                Text("Loading course...")
-                    .task { await loadCourse() }
+                ProgressView("Loading course...")
                     .tabItem { Label("GPS", systemImage: "flag") }
             }
 
             NavigationView { ScorecardView(scorecard: scorecard) }
                 .tabItem { Label("Scorecard", systemImage: "pencil") }
+        }
+        .task {
+            if course == nil {
+                await loadCourse()
+            }
         }
     }
 

--- a/golfy/golfy/Services/CourseService.swift
+++ b/golfy/golfy/Services/CourseService.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+private struct OSMResponse: Codable {
+    let elements: [OSMElement]
+}
+
+private struct OSMElement: Codable {
+    let type: String
+    let id: Int
+    let lat: Double?
+    let lon: Double?
+    let center: Coordinate?
+    let tags: [String: String]?
+
+    var coordinate: Coordinate? {
+        if let center { return center }
+        if let lat, let lon { return Coordinate(lat: lat, lon: lon) }
+        return nil
+    }
+}
+
 actor CourseService {
     static let shared = CourseService()
     private let cacheURL: URL
@@ -10,14 +29,32 @@ actor CourseService {
     }
 
     func loadCourse(forceReload: Bool = false) async throws -> Course {
-        if !forceReload, let data = try? Data(contentsOf: cacheURL) {
-            return try JSONDecoder().decode(Course.self, from: data)
+        let data: Data
+        if !forceReload, let cached = try? Data(contentsOf: cacheURL) {
+            data = cached
+        } else {
+            guard let bundleURL = Bundle.main.url(forResource: "course", withExtension: "json") else {
+                throw NSError(domain: "CourseService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing course.json in bundle"])
+            }
+            data = try Data(contentsOf: bundleURL)
+            try data.write(to: cacheURL, options: .atomic)
         }
-        guard let bundleURL = Bundle.main.url(forResource: "course", withExtension: "json") else {
-            throw NSError(domain: "CourseService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing course.json in bundle"])
+        return try decodeOSM(data)
+    }
+
+    private func decodeOSM(_ data: Data) throws -> Course {
+        let response = try JSONDecoder().decode(OSMResponse.self, from: data)
+        let tees = response.elements.filter { $0.tags?["golf"] == "tee" }
+        let greens = response.elements.filter { $0.tags?["golf"] == "green" }
+        let count = min(tees.count, greens.count)
+        var holes: [Hole] = []
+        for i in 0..<count {
+            guard let teeCoord = tees[i].coordinate,
+                  let greenCoord = greens[i].coordinate else { continue }
+            let teeFeature = CourseFeature(id: tees[i].id, type: .tee, points: [teeCoord])
+            let greenFeature = CourseFeature(id: greens[i].id, type: .green, points: [greenCoord])
+            holes.append(Hole(id: i + 1, par: 4, features: [teeFeature, greenFeature]))
         }
-        let data = try Data(contentsOf: bundleURL)
-        try data.write(to: cacheURL, options: .atomic)
-        return try JSONDecoder().decode(Course.self, from: data)
+        return Course(name: "OSM Course", holes: holes)
     }
 }

--- a/golfy/golfy/Views/CourseListView.swift
+++ b/golfy/golfy/Views/CourseListView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct CourseListItem: Identifiable {
+    let id = UUID()
+    let name: String
+}
+
+struct CourseListView: View {
+    @State private var search = ""
+    private let nearby: [CourseListItem] = [
+        .init(name: "Green Valley Golf Club"),
+        .init(name: "River Ridge Golf Club"),
+    ]
+    private let recent: [CourseListItem] = [
+        .init(name: "Sunvalley Golf Course"),
+    ]
+
+    var body: some View {
+        List {
+            Section("Nearby") {
+                ForEach(filter(nearby)) { item in
+                    CourseRow(item: item)
+                }
+            }
+            Section("Recent") {
+                ForEach(filter(recent)) { item in
+                    CourseRow(item: item)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Course")
+        .searchable(text: $search)
+    }
+
+    private func filter(_ items: [CourseListItem]) -> [CourseListItem] {
+        if search.isEmpty { return items }
+        return items.filter { $0.name.localizedCaseInsensitiveContains(search) }
+    }
+}
+
+struct CourseRow: View {
+    let item: CourseListItem
+    var body: some View {
+        HStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.green)
+                .frame(width: 60, height: 60)
+            Text(item.name)
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    NavigationView { CourseListView() }
+}

--- a/golfy/golfy/Views/HistoryView.swift
+++ b/golfy/golfy/Views/HistoryView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct PastRound: Identifiable {
+    let id = UUID()
+    let date: Date
+    let course: String
+    let score: Int
+}
+
+struct HistoryView: View {
+    private let rounds: [PastRound] = [
+        PastRound(date: Date().addingTimeInterval(-86400 * 2), course: "Links at St Andrews", score: 72),
+        PastRound(date: Date().addingTimeInterval(-86400 * 30), course: "Pebble Beach", score: 80),
+    ]
+
+    var body: some View {
+        List {
+            ForEach(groupedRounds.keys.sorted(by: >), id: \.self) { month in
+                Section(monthFormatter.string(from: month)) {
+                    ForEach(groupedRounds[month]!) { round in
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(dateFormatter.string(from: round.date))
+                                    .font(.subheadline)
+                                Text(round.course)
+                            }
+                            Spacer()
+                            Text("\(round.score)")
+                                .foregroundStyle(round.score <= 72 ? Color.green : Color.red)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Past Rounds")
+    }
+
+    private var groupedRounds: [Date: [PastRound]] {
+        Dictionary(grouping: rounds) { round in
+            let comps = Calendar.current.dateComponents([.year, .month], from: round.date)
+            return Calendar.current.date(from: comps) ?? round.date
+        }
+    }
+
+    private var monthFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "LLLL yyyy"
+        return df
+    }
+
+    private var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        return df
+    }
+}
+
+#Preview {
+    NavigationView { HistoryView() }
+}

--- a/golfy/golfy/Views/HoleCartoonView.swift
+++ b/golfy/golfy/Views/HoleCartoonView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct HoleCartoonView: View {
+    let hole: Hole
+
+    var body: some View {
+        GeometryReader { geo in
+            if let tee = hole.tee?.points.first, let green = hole.green?.points.first {
+                let minLat = min(tee.lat, green.lat)
+                let maxLat = max(tee.lat, green.lat)
+                let minLon = min(tee.lon, green.lon)
+                let maxLon = max(tee.lon, green.lon)
+                let scaleX = geo.size.width / CGFloat(maxLon - minLon)
+                let scaleY = geo.size.height / CGFloat(maxLat - minLat)
+
+                let teePoint = CGPoint(x: CGFloat(tee.lon - minLon) * scaleX,
+                                       y: geo.size.height - CGFloat(tee.lat - minLat) * scaleY)
+                let greenPoint = CGPoint(x: CGFloat(green.lon - minLon) * scaleX,
+                                         y: geo.size.height - CGFloat(green.lat - minLat) * scaleY)
+
+                Path { path in
+                    path.move(to: teePoint)
+                    path.addLine(to: greenPoint)
+                }
+                .stroke(Color.brown, lineWidth: 4)
+
+                Circle()
+                    .fill(Color.blue)
+                    .frame(width: 16, height: 16)
+                    .position(teePoint)
+
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 24, height: 24)
+                    .position(greenPoint)
+            }
+        }
+    }
+}
+
+#Preview {
+    HoleCartoonView(hole: Course(name: "", holes: [Hole(id: 1, par: 4, features: [
+        CourseFeature(id: 1, type: .tee, points: [Coordinate(lat: 0, lon: 0)]),
+        CourseFeature(id: 2, type: .green, points: [Coordinate(lat: 1, lon: 1)])
+    ])]).holes[0])
+}

--- a/golfy/golfy/Views/HolePagerView.swift
+++ b/golfy/golfy/Views/HolePagerView.swift
@@ -4,7 +4,7 @@ import CoreLocation
 private struct HolePage: View {
     let hole: Hole
     @ObservedObject var locationManager: LocationManager
-    @Binding var score: HoleScore
+    @ObservedObject var scorecard: Scorecard
 
     var body: some View {
         VStack(spacing: 16) {
@@ -19,16 +19,16 @@ private struct HolePage: View {
                     Text(String(format: "B %.0f yd", yards.back))
                 }
             }
-            Stepper(value: $score.strokes, in: 0...20) {
-                Text("Strokes: \(score.strokes)")
-            }
-            Stepper(value: $score.putts, in: 0...10) {
-                Text("Putts: \(score.putts)")
-            }
-            NavigationLink("Targets") {
-                TargetsListView(locationManager: locationManager, hole: hole)
-            }
             Spacer()
+            HStack {
+                Button("Add Shot") {}
+                Spacer()
+                NavigationLink("Scorecard") {
+                    ScorecardView(scorecard: scorecard)
+                }
+                Spacer()
+                Button("Move Pin") {}
+            }
         }
         .padding()
     }
@@ -50,7 +50,7 @@ struct HolePagerView: View {
         VStack {
             HolePage(hole: course.holes[index],
                      locationManager: locationManager,
-                     score: binding(for: course.holes[index].id))
+                     scorecard: scorecard)
             HStack {
                 Button("Back") { index -= 1 }
                     .disabled(index == 0)
@@ -60,10 +60,5 @@ struct HolePagerView: View {
             }
             .padding(.horizontal)
         }
-    }
-
-    private func binding(for holeID: Int) -> Binding<HoleScore> {
-        let idx = scorecard.holes.firstIndex { $0.id == holeID }!
-        return $scorecard.holes[idx]
     }
 }

--- a/golfy/golfy/Views/HolePagerView.swift
+++ b/golfy/golfy/Views/HolePagerView.swift
@@ -10,7 +10,7 @@ private struct HolePage: View {
         VStack(spacing: 16) {
             Text("Hole \(hole.id) - Par \(hole.par)")
                 .font(.title2)
-            HoleMapView(locationManager: locationManager, hole: hole)
+            HoleCartoonView(hole: hole)
                 .frame(height: 250)
             if let yards = yardages {
                 HStack {
@@ -44,20 +44,26 @@ struct HolePagerView: View {
     let course: Course
     @ObservedObject var locationManager: LocationManager
     @ObservedObject var scorecard: Scorecard
+    @State private var index = 0
 
     var body: some View {
-        TabView {
-            ForEach(course.holes) { hole in
-                HolePage(hole: hole,
-                         locationManager: locationManager,
-                         score: binding(for: hole.id))
+        VStack {
+            HolePage(hole: course.holes[index],
+                     locationManager: locationManager,
+                     score: binding(for: course.holes[index].id))
+            HStack {
+                Button("Back") { index -= 1 }
+                    .disabled(index == 0)
+                Spacer()
+                Button("Next") { index += 1 }
+                    .disabled(index == course.holes.count - 1)
             }
+            .padding(.horizontal)
         }
-        .tabViewStyle(.page)
     }
 
     private func binding(for holeID: Int) -> Binding<HoleScore> {
-        let index = scorecard.holes.firstIndex { $0.id == holeID }!
-        return $scorecard.holes[index]
+        let idx = scorecard.holes.firstIndex { $0.id == holeID }!
+        return $scorecard.holes[idx]
     }
 }

--- a/golfy/golfy/Views/ProfileView.swift
+++ b/golfy/golfy/Views/ProfileView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @State private var name = "Golfer"
+    @State private var email = "golfer@example.com"
+    @State private var handicap = "10"
+    @State private var notifications = true
+
+    var body: some View {
+        Form {
+            Section("Personal Information") {
+                TextField("Name", text: $name)
+                TextField("Email", text: $email)
+                TextField("Handicap", text: $handicap)
+                    .keyboardType(.numberPad)
+            }
+            Section("Settings") {
+                Toggle("Notifications", isOn: $notifications)
+            }
+        }
+        .navigationTitle("Profile")
+    }
+}
+
+#Preview {
+    NavigationView { ProfileView() }
+}

--- a/golfy/golfy/Views/ScorecardView.swift
+++ b/golfy/golfy/Views/ScorecardView.swift
@@ -73,22 +73,33 @@ private struct HolePageView: View {
 
 struct ScorecardView: View {
     @ObservedObject var scorecard: Scorecard
+    @State private var index = 0
 
     var body: some View {
-        TabView {
-            ForEach($scorecard.holes) { $hole in
-                HolePageView(hole: $hole)
+        VStack {
+            if index < scorecard.holes.count {
+                HolePageView(hole: $scorecard.holes[index])
+            } else {
+                VStack(spacing: 8) {
+                    Text("Totals")
+                        .font(.title2)
+                    Text("Strokes: \(scorecard.totalStrokes)")
+                    Text("Putts: \(scorecard.totalPutts)")
+                    Spacer()
+                }
+                .padding()
             }
-            VStack(spacing: 8) {
-                Text("Totals")
-                    .font(.title2)
-                Text("Strokes: \(scorecard.totalStrokes)")
-                Text("Putts: \(scorecard.totalPutts)")
+            HStack {
+                Button("Back") { index -= 1 }
+                    .disabled(index == 0)
                 Spacer()
+                Button(index < scorecard.holes.count ? "Next" : "Done") {
+                    if index < scorecard.holes.count { index += 1 }
+                }
+                .disabled(index == scorecard.holes.count)
             }
             .padding()
         }
-        .tabViewStyle(.page)
         .navigationTitle("Scorecard")
         .toolbar { Button("Save") { scorecard.save() } }
     }

--- a/golfy/golfy/Views/ScorecardView.swift
+++ b/golfy/golfy/Views/ScorecardView.swift
@@ -1,26 +1,76 @@
 import SwiftUI
 
-/// View for editing a single hole's score
-private struct HolePageView: View {
-    @Binding var hole: HoleScore
+private struct NumberPad: View {
+    let onInput: (Int?) -> Void
+
+    private let rows = [
+        ["1","2","3"],
+        ["4","5","6"],
+        ["7","8","9"],
+        ["", "0", "del"]
+    ]
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 12) {
+            ForEach(rows, id: \.self) { row in
+                HStack(spacing: 12) {
+                    ForEach(row, id: \.self) { item in
+                        if item.isEmpty {
+                            Color.clear.frame(width: 60, height: 60)
+                        } else {
+                            Button {
+                                if item == "del" {
+                                    onInput(nil)
+                                } else if let num = Int(item) {
+                                    onInput(num)
+                                }
+                            } label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color.gray.opacity(0.2))
+                                    if item == "del" {
+                                        Image(systemName: "delete.left")
+                                    } else {
+                                        Text(item)
+                                    }
+                                }
+                                .frame(width: 60, height: 60)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct HolePageView: View {
+    @Binding var hole: HoleScore
+    @State private var entry = ""
+
+    var body: some View {
+        VStack(spacing: 32) {
             Text("Hole \(hole.id)")
                 .font(.title)
-            Stepper(value: $hole.strokes, in: 0...20) {
-                Text("Strokes: \(hole.strokes)")
+            Text(entry.isEmpty ? "0" : entry)
+                .font(.system(size: 64, weight: .bold))
+
+            NumberPad { value in
+                if let num = value {
+                    entry.append(String(num))
+                } else if !entry.isEmpty {
+                    entry.removeLast()
+                }
+                hole.strokes = Int(entry) ?? 0
             }
-            Stepper(value: $hole.putts, in: 0...10) {
-                Text("Putts: \(hole.putts)")
-            }
+
             Spacer()
         }
         .padding()
     }
 }
 
-/// Simple scorecard allowing strokes and putts per hole with swipeable pages
 struct ScorecardView: View {
     @ObservedObject var scorecard: Scorecard
 

--- a/golfy/golfy/Views/StartRoundView.swift
+++ b/golfy/golfy/Views/StartRoundView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct StartRoundView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("START ROUND")
+                    .font(.title)
+                    .bold()
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Last Round")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Text("18 Hol")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("77")
+                            .font(.system(size: 48, weight: .bold))
+                    }
+                    Spacer()
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("72°", systemImage: "sun.max")
+                        Label("5 mph", systemImage: "wind")
+                    }
+                }
+            }
+
+            NavigationLink("Start Round") {
+                CourseListView()
+            }
+            .buttonStyle(.borderedProminent)
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    NavigationView { StartRoundView() }
+}

--- a/golfy/golfy/course.json
+++ b/golfy/golfy/course.json
@@ -1,30 +1,14 @@
 {
-  "name": "Sample Links",
-  "holes": [
-    {
-      "id": 1,
-      "par": 4,
-      "features": [
-        {"id": 1, "type": "tee", "points": [{"lat": 56.3417, "lon": -2.7955}]},
-        {"id": 2, "type": "green", "points": [
-          {"lat": 56.3423, "lon": -2.7935},
-          {"lat": 56.3424, "lon": -2.7938},
-          {"lat": 56.3426, "lon": -2.7936}
-        ]},
-        {"id": 3, "type": "bunker", "points": [{"lat": 56.3419, "lon": -2.7945}]}
-      ]
-    },
-    {
-      "id": 2,
-      "par": 3,
-      "features": [
-        {"id": 4, "type": "tee", "points": [{"lat": 56.3428, "lon": -2.7920}]},
-        {"id": 5, "type": "green", "points": [
-          {"lat": 56.3432, "lon": -2.7905},
-          {"lat": 56.3433, "lon": -2.7908},
-          {"lat": 56.3435, "lon": -2.7906}
-        ]}
-      ]
-    }
+  "version": 0.6,
+  "generator": "Custom",
+  "elements": [
+    {"type": "way", "id": 1, "center": {"lat": 60.1675692, "lon": -1.2251892}, "tags": {"golf": "green"}},
+    {"type": "way", "id": 2, "center": {"lat": 60.1671579, "lon": -1.2267125}, "tags": {"golf": "tee"}},
+    {"type": "way", "id": 3, "center": {"lat": 60.1695436, "lon": -1.2236724}, "tags": {"golf": "green"}},
+    {"type": "way", "id": 4, "center": {"lat": 60.1693118, "lon": -1.2231894}, "tags": {"golf": "tee"}},
+    {"type": "way", "id": 5, "center": {"lat": 60.1704163, "lon": -1.2223922}, "tags": {"golf": "green"}},
+    {"type": "way", "id": 6, "center": {"lat": 60.1707006, "lon": -1.2219184}, "tags": {"golf": "tee"}},
+    {"type": "way", "id": 7, "center": {"lat": 60.1694650, "lon": -1.2166344}, "tags": {"golf": "green"}},
+    {"type": "way", "id": 8, "center": {"lat": 60.1689457, "lon": -1.2172928}, "tags": {"golf": "tee"}}
   ]
 }


### PR DESCRIPTION
## Summary
- Integrate a new Start Round tab and course list into the main tab view
- Provide searchable course listing with placeholder images
- Redesign scorecard screen with a keypad-based stroke entry

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31d1046548320bad1dcf5532c64a2