### PR TITLE
Add loading state and error handling for course fetching

### DIFF
--- a/golfy/golfy/ContentView.swift
+++ b/golfy/golfy/ContentView.swift
@@ -4,6 +4,9 @@ struct ContentView: View {
     @StateObject var locationManager = LocationManager()
     @StateObject var scorecard = Scorecard()
     @State private var course: Course?
+    @State private var isLoading = true
+    @State private var errorMessage = ""
+    @State private var showError = false
 
     var body: some View {
         TabView {
@@ -19,8 +22,11 @@ struct ContentView: View {
                         .navigationTitle(course.name)
                 }
                 .tabItem { Label("GPS", systemImage: "flag") }
-            } else {
+            } else if isLoading {
                 ProgressView("Loading course...")
+                    .tabItem { Label("GPS", systemImage: "flag") }
+            } else {
+                Text("Failed to load course")
                     .tabItem { Label("GPS", systemImage: "flag") }
             }
 
@@ -35,12 +41,25 @@ struct ContentView: View {
                 await loadCourse()
             }
         }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage)
+        }
     }
 
     private func loadCourse() async {
-        if let loaded = try? await CourseService.shared.loadCourse() {
+        isLoading = true
+        showError = false
+        do {
+            let loaded = try await CourseService.shared.loadCourse()
             course = loaded
             scorecard.setupHoles(count: loaded.holes.count)
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
+            isLoading = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- show a ProgressView during course loading with a new `isLoading` state
- surface load failures via an alert and inline message
- reset loading state on success and failure

## Testing
- `xcodebuild -project golfy.xcodeproj -scheme golfy test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc3fee0c8320835fcca7ba7e5e85