### PR TITLE
Add Swift Package manifest for tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "golfy",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(name: "golfy", targets: ["golfy"])
+    ],
+    targets: [
+        .target(
+            name: "golfy",
+            path: "golfy/golfy",
+            resources: [
+                .process("course.json"),
+                .process("Assets.xcassets"),
+                .process("golfy.xcdatamodeld")
+            ]
+        ),
+        .testTarget(
+            name: "golfyTests",
+            dependencies: ["golfy"],
+            path: "golfy/golfyTests"
+        ),
+        .testTarget(
+            name: "golfyUITests",
+            dependencies: ["golfy"],
+            path: "golfy/golfyUITests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add `Package.swift` to define package structure for golfy app and test targets

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68b5cd17ef10832094c766d0e8a3397f